### PR TITLE
Implement time-based note queries and search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Byte-compiled / cache
+__pycache__/
+.pytest_cache/
+
+# Build artifacts
+build/
+*.egg-info/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,9 @@ This document explains repository structure, coding conventions, and the workflo
 
 1. **Python ≥ 3.8**; stick to the standard library – no external runtime deps.
 2. Every new function must have a docstring.
-3. Run `python -m pip install -e .[dev]` then `pytest` (future test suite).
+3. **Before committing**, run `python -m pip install -e .[dev]` then `pytest`.
+   Once tests pass with no errors, update all documentation that references the
+   changed functionality.
 4. Preserve backward compatibility of the CLI interface listed in `README.md`.
 5. User config lives at `~/.timestampr/config.json`; do **NOT** move or rename this without a major version bump.
 
@@ -93,5 +95,10 @@ No runtime network access is necessary.
 
 * Split README_and_AGENTS.md into README.md and AGENTS.md; removed old README
 * Added initial test suite and updated docs
+* No issues
+
+## 2025-07-30  @Donnie
+
+* Reworked README intro and command table; other minor wording fixes
 * No issues
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ If you were using `timestampr(CLI)`:
 `timestampr(CLI)` lets you jot ultra-quick notes from any terminal.\
 Each notebook is just a folder on your laptop;\
 Each page is a `.csv` file inside that folder;\
-Each line is simply:
+Each line is now:
 
 ```
-YYYY-MM-DD HH:MM:SS,Your note text…
+YYYY-MM-DD,HH:MM:SS,Your note text…
 ```
 
 Since it is plain text, you can easily **grep**, **sync to the cloud**, or **open in Excel**.
@@ -66,12 +66,13 @@ stamp - inoculated flasks 7-9
 | `stamp foot N` (e.g. `stamp foot 25`)                 | Show last N notes                       |
 | `stamp foot all`                                      | Show all notes                          |
 | `stamp notetime X` (1-based index)                    | Show timestamp of note #X               |
-| `stamp timenote Y` (e.g. `stamp timenote 2025-07-30`) | Show note whose timestamp starts with Y |
+| `stamp timenote Y` (e.g. `stamp timenote 08:30`)      | Show notes at time Y or range |
+| `stamp search text`                                   | Find notes containing `text` |
 
 For peace of mind, a message like this appears every time a note is added successfully:
 
 ```
-stamp success: page daily_log timestamp 2025-07-30 15:42:01 note fixed bug in…
+stamp success: daily_log 2025-07-30 15:42:01 fixed bug in…
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name            = "timestampr"
 version         = "0.1.0"
 description     = "Bare‑bones note‑taker with timestamp"
-authors         = [{ name = "Your Name" }]
+authors         = [{ name = "Donnie McFarlane" }]
 license         = { text = "MIT" }
 requires-python = ">=3.8"
 


### PR DESCRIPTION
## Summary
- record date and time in separate CSV columns
- allow querying notes by time or time range
- add ability to search active page
- clarify contribution rules
- document new behaviour and update author
- ignore build artifacts

## Testing
- `python -m pip install -e .[dev]`
- `ruff check timestampr`
- `python -m pip check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b06f9e994832ca08b0d68b5606005