### PR TITLE
Improve note input handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,3 +121,10 @@ No runtime network access is necessary.
 * Verified Windows compatibility
 * No issues
 
+
+## 2025-08-01  @assistant
+
+* Added helper `_read_note_from_stdin_or_prompt` and updated CLI to accept piped or interactive notes
+* Documented quoting and piping special characters in README
+* Added tests covering new helper and dash behavior
+* No issues

--- a/README.md
+++ b/README.md
@@ -72,6 +72,51 @@ For peace of mind, a message like this appears every time a note is added succes
 stamp success: wetlab_log 2025-07-30 15:42:01 inoculated all flasks for overnight culture…
 ```
 
+### 3.1 Special Characters (PowerShell / CMD / Bash)
+
+Some characters like `&`, `|`, `(`, `)`, `{`, `}`, `[`, `]`, `"`, `,`, `#`, and `@` are interpreted by your shell before `stamp` sees them. Use one of the approaches below:
+
+#### Easiest: interactive entry
+
+```
+stamp -
+note> fix @mentions & quotes "double", hash #, pipe |, braces { } [ ] ( ) , commas
+```
+
+#### Pipe the note via stdin
+
+```
+printf '%s' 'ALL SPECIALS: # & " @ ( { [ | , } ] ) ^ ~ ! $ % * +' | stamp -
+```
+
+#### PowerShell
+
+Use single quotes for literal text and double a single quote inside:
+
+```
+stamp - 'fix @mentions & quotes "double", hash #, pipe |, braces { } [ ] ( ) , commas'
+stamp - 'Don''t break single quotes'
+```
+
+#### Windows CMD
+
+Prefer interactive mode (`stamp -`) or escape operators with `^` when using quotes:
+
+```
+stamp - "fix @mentions & quotes ""double"", hash #, pipe ^|, braces { } [ ] ( ) , commas"
+```
+
+#### Bash / Zsh
+
+Use single quotes for literal text; escape a single quote by closing and reopening:
+
+```
+stamp - 'fix @mentions & quotes "double", hash #, pipe |, braces { } [ ] ( ) , commas'
+stamp - 'Don'\''t break single quotes'
+```
+
+> CSV safety: Notes are saved with `csv.writer`, so commas and quotes are handled correctly.
+
 ---
 
 ## 4 - Installation

--- a/tests/test_dash.py
+++ b/tests/test_dash.py
@@ -1,0 +1,83 @@
+import io
+import json
+from pathlib import Path
+import builtins
+
+import pytest
+
+from timestampr import cli
+
+
+def setup_config(tmp_path: Path):
+    """Prepare a temporary config and notebook/page."""
+    nb = tmp_path / "notebook"
+    nb.mkdir(parents=True, exist_ok=True)
+    page = "testpage"
+    (nb / f"{page}.csv").touch()
+    cfg_dir = tmp_path / ".timestampr"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / "config.json").write_text(
+        json.dumps({"notebook": str(nb), "page": page}), encoding="utf-8"
+    )
+    return cfg_dir, nb, page
+
+
+class FakeStdin(io.StringIO):
+    def isatty(self):
+        return False
+
+
+def read_last_note(csv_path: Path) -> str:
+    lines = csv_path.read_text(encoding="utf-8").splitlines()
+    assert lines, "Expected at least one note row"
+    import csv
+    date, tm, note = next(csv.reader([lines[-1]]))
+    assert date and tm
+    return note
+
+
+def test_dash_with_args_writes_note(tmp_path, monkeypatch):
+    cfg_dir, nb, page = setup_config(tmp_path)
+    monkeypatch.setattr(cli, "CONFIG_DIR", cfg_dir)
+    monkeypatch.setattr(cli, "CONFIG_FILE", cfg_dir / "config.json")
+    cli.main(["-", "a", "&", "b"])
+    note = read_last_note(nb / f"{page}.csv")
+    assert note == "a & b"
+
+
+def test_dash_reads_stdin(tmp_path, monkeypatch):
+    cfg_dir, nb, page = setup_config(tmp_path)
+    monkeypatch.setattr(cli, "CONFIG_DIR", cfg_dir)
+    monkeypatch.setattr(cli, "CONFIG_FILE", cfg_dir / "config.json")
+    fake = FakeStdin("x & y\n")
+    monkeypatch.setattr(cli.sys, "stdin", fake)
+    cli.main(["-"])
+    note = read_last_note(nb / f"{page}.csv")
+    assert note == "x & y"
+
+
+def test_dash_prompt_branch_via_helper(tmp_path, monkeypatch):
+    cfg_dir, nb, page = setup_config(tmp_path)
+    monkeypatch.setattr(cli, "CONFIG_DIR", cfg_dir)
+    monkeypatch.setattr(cli, "CONFIG_FILE", cfg_dir / "config.json")
+    monkeypatch.setattr(
+        cli, "_read_note_from_stdin_or_prompt", lambda: 'note with # and , and " quotes'
+    )
+    cli.main(["-"])
+    note = read_last_note(nb / f"{page}.csv")
+    assert note == 'note with # and , and " quotes'
+
+
+def test_read_note_from_stdin_or_prompt_reads_stdin(monkeypatch):
+    fake = FakeStdin("foo\n")
+    monkeypatch.setattr(cli.sys, "stdin", fake)
+    assert cli._read_note_from_stdin_or_prompt() == "foo"
+
+
+def test_read_note_from_stdin_or_prompt_prompts(monkeypatch):
+    class Tty(io.StringIO):
+        def isatty(self):
+            return True
+    monkeypatch.setattr(cli.sys, "stdin", Tty())
+    monkeypatch.setattr(builtins, "input", lambda _: "bar")
+    assert cli._read_note_from_stdin_or_prompt() == "bar"


### PR DESCRIPTION
## Summary
- add `_read_note_from_stdin_or_prompt` helper
- change `stamp -` logic to use the helper
- document quoting of special characters in README
- test new helper and dash behaviour

## Testing
- `python -m pip install -e .[dev]`
- `ruff check timestampr`
- `pytest -q`
- `python -m pip check`


------
https://chatgpt.com/codex/tasks/task_e_688c5ff2d3d8832ca25757c75ee6b0c2